### PR TITLE
Switch to UPX instead of strip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,16 @@ dist:
 	rm -r $(NAME)
 
 binarydist: adplay.exe
-	upx adplay.exe
+	echo "Compressing adplay.exe"
+	@if which upx > /dev/null; then \
+		upx --best adplay.exe; \
+	elif which strip > /dev/null; then \
+		echo "WARNING: Using strip, since upx is not found. Please consider installing upx since it gives the best compression of the binary. Also see UPX manpage https://github.com/upx/upx/blob/250c656b9eb24b0fb54fe8c015d38b0eba5ee80c/doc/upx-doc.txt#L272C6-L272C6 for additional information on upx vs strip."; \
+		strip adplay.exe; \
+		echo "strip completed"; \
+	else \
+		echo "ERROR: strip not found, please install either upx or strip" && exit 1; \
+	fi
 	rm -rf $(BINARYNAME).zip $(BINARYNAME)
 	mkdir $(BINARYNAME)
 	cp $(BINARYDIST) $(BINARYNAME)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 INSTALL = install
-STRIP = strip
 ZIP = zip
 
 prefix = /usr/local/djgpp
@@ -47,7 +46,7 @@ dist:
 	rm -r $(NAME)
 
 binarydist: adplay.exe
-	$(STRIP) adplay.exe
+	upx adplay.exe
 	rm -rf $(BINARYNAME).zip $(BINARYNAME)
 	mkdir $(BINARYNAME)
 	cp $(BINARYDIST) $(BINARYNAME)


### PR DESCRIPTION
This creates smaller binaries, and seems to be a better option than strip for DJGPP binaries.
See https://www.delorie.com/djgpp/v2faq/faq8_14.html end of the page. Seems a special DJP executable compressor was developed at some point, but development has since shifted to UPX.