### PR TITLE
Add batch player test as part of CI (smoke test)

### DIFF
--- a/.github/workflows/docker-adplay-build.yml
+++ b/.github/workflows/docker-adplay-build.yml
@@ -93,10 +93,11 @@ jobs:
             pushd adplay
             make gcc_version=${{ matrix.gcc_compiler }} binarydist
             popd
-        - name: Test AdPlay for DOS
+        - name: Test AdPlay for DOS (batch player)
           run: |
-            # Please note that this only tests basic batch player functionality
-            # It does not test specific formats, this is already handled through Adplug specific tests, which are also run for DOS!
+            # This tests basic batch player functionality
+            # It does NOT test specific formats, this is already handled through Adplug specific tests, which are also run for DOS.
+            # It also does NOT test any GUI interaction
             pushd adplay
             # Install dosemu2 for testing
             sudo add-apt-repository -y ppa:dosemu2/ppa
@@ -105,6 +106,7 @@ jobs:
             wget https://www.delorie.com/pub/djgpp/current/v2misc/csdpmi7b.zip
             unzip -j -o "csdpmi7b.zip" "bin/CWSDPMI.EXE"
             cp ../adplug/test/testmus/loudness.lds .
+            # Command below will execute AdPlay for Dos in dosemu, dosemu will relay the exitcode back, which in turn will be interpreted by the GitHub run action
             dosemu adplay.exe -dumb /q loudness.lds
 
         - name: Tag this version 'latest'

--- a/.github/workflows/docker-adplay-build.yml
+++ b/.github/workflows/docker-adplay-build.yml
@@ -92,6 +92,19 @@ jobs:
             pushd adplay
             make gcc_version=${{ matrix.gcc_compiler }} binarydist
             popd
+        - name: Test AdPlay for DOS
+          run: |
+            # Please note that this only tests basic batch player functionality
+            # It does not test specific formats, this is already handled through Adplug specific tests, which are also run for DOS!
+            pushd adplay
+            # Install dosemu2 for testing
+            sudo add-apt-repository -y ppa:dosemu2/ppa
+            sudo apt install -y dosemu2 unzip
+            # We need CWSDPMI as well if we want to run any DOS programs.
+            wget https://www.delorie.com/pub/djgpp/current/v2misc/csdpmi7b.zip
+            unzip -j -o "csdpmi7b.zip" "bin/CWSDPMI.EXE"
+            cp ../adplug/test/testmus/loudness.lds .
+            dosemu adplay.exe -dumb /q loudness.lds
         - name: Upload artifact
           uses: actions/upload-artifact@v3
           with:


### PR DESCRIPTION
This PR aims to add a basic batch player test to the CI for Adplay for DOS. It's based on my [previous work done for Adplug DOS compatibility](https://github.com/adplug/adplug/blob/master/.github/workflows/build.yml#L123)

It  checks if the executeable actually runs, and no errors are returned. It does not validate the audio output in any way, just that adplay was able to run, play a file in batch mode, and not return any error codes.

Sidenote regarding audio output validation:
I'd really like to be able to crosscheck Adplay for DOS playback with the Adplay for Linux version, to see if there is any regression or other weird issue in the DOS version.
I've ran into issues trying to automate this, since capturing audio from emulated DOS environments can be done, but the emulation causes slight variations in the captured waveforms due to timing differences introduced with the emulation. For example comparing wave/DRO output recordings from multiple DOSBoxX runs show different results each run. I've tried writing a [tool](https://github.com/AranVink/dro-compare) to compensate, but have yet to integrate it further. Also doing this takes quite a long time, since all test files will have to be played through a emulator in full, at actual speed.